### PR TITLE
Add Mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Official PyTorch implementation of **YOLOE**.
 
 [YOLOE: Real-Time Seeing Anything](https://arxiv.org/abs/2503.07465).\
 Ao Wang*, Lihao Liu*, Hui Chen, Zijia Lin, Jungong Han, and Guiguang Ding\
-[![arXiv](https://img.shields.io/badge/arXiv-2503.07465-b31b1b.svg)](https://arxiv.org/abs/2503.07465) [![Hugging Face Models](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Models-blue)](https://huggingface.co/jameslahm/yoloe/tree/main) [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/jameslahm/yoloe) [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/zero-shot-object-detection-and-segmentation-with-yoloe.ipynb)
+[![arXiv](https://img.shields.io/badge/arXiv-2503.07465-b31b1b.svg)](https://arxiv.org/abs/2503.07465) [![Hugging Face Models](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Models-blue)](https://huggingface.co/jameslahm/yoloe/tree/main) [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/jameslahm/yoloe) [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/zero-shot-object-detection-and-segmentation-with-yoloe.ipynb) [![Hugging Face Collection](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Collection-blue)](https://huggingface.co/collections/jameslahm/yoloe-67d5110aabaefbe129c15917)
 
 
 We introduce **YOLOE(ye)**, a highly **efficient**, **unified**, and **open** object detection and segmentation model, like human eye, under different prompt mechanisms, like *texts*, *visual inputs*, and *prompt-free paradigm*, with **zero inference and transferring overhead** compared with closed-set YOLOs.
@@ -137,6 +137,11 @@ python app.py
 # Please replace the pt file with your desired model
 pip install huggingface-hub==0.26.3
 huggingface-cli download jameslahm/yoloe yoloe-v8l-seg.pt --local-dir pretrain
+```
+For yoloe-(v8s/m/l)/(11s/m/l)-seg, Models can also be automatically downloaded using `from_pretrained`.
+```python
+from ultralytics import YOLOE
+model = YOLOE.from_pretrained("jameslahm/yoloe-v8l-seg")
 ```
 
 ### Text prompt

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -152,6 +152,12 @@ class Model(nn.Module, PyTorchModelHubMixin,
         # Delete super().training for accessing self.model.training
         del self.training
 
+    def push_to_hub(self, repo_name, **kwargs):
+        config = kwargs.get("config", {})
+        config["model"] = self.model.yaml["yaml_file"]
+        kwargs["config"] = config
+        super().push_to_hub(repo_name, **kwargs)
+    
     def __call__(
         self,
         source: Union[str, Path, int, Image.Image, list, tuple, np.ndarray, torch.Tensor] = None,

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -8,6 +8,8 @@ import numpy as np
 import torch
 from PIL import Image
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from ultralytics.cfg import TASK2DATA, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
 from ultralytics.hub import HUB_WEB_ROOT, HUBTrainingSession
@@ -26,7 +28,10 @@ from ultralytics.utils import (
 )
 
 
-class Model(nn.Module):
+class Model(nn.Module, PyTorchModelHubMixin,
+           repo_url="https://github.com/THU-MIG/yoloe",
+           pipeline_tag="zero-shot-object-detection",
+           license="agpl-3.0"):
     """
     A base class for implementing YOLO models, unifying APIs across different model types.
 

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -2,18 +2,13 @@
 
 from pathlib import Path
 
-from huggingface_hub import PyTorchModelHubMixin
-
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, OBBModel, PoseModel, SegmentationModel, YOLOEModel, YOLOESegModel
 from ultralytics.utils import ROOT, yaml_load
 
 
-class YOLO(Model, PyTorchModelHubMixin,
-           repo_url="https://github.com/THU-MIG/yoloe",
-           pipeline_tag="zero-shot-object-detection",
-           license="agpl-3.0"):
+class YOLO(Model):
     """YOLO (You Only Look Once) object detection model."""
 
     def __init__(self, model="yolo11n.pt", task=None, verbose=False):

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -2,13 +2,18 @@
 
 from pathlib import Path
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, OBBModel, PoseModel, SegmentationModel, YOLOEModel, YOLOESegModel
 from ultralytics.utils import ROOT, yaml_load
 
 
-class YOLO(Model):
+class YOLO(Model, PyTorchModelHubMixin,
+           repo_url="https://github.com/THU-MIG/yoloe",
+           pipeline_tag="zero-shot-object-detection",
+           license="agpl-3.0"):
     """YOLO (You Only Look Once) object detection model."""
 
     def __init__(self, model="yolo11n.pt", task=None, verbose=False):


### PR DESCRIPTION
This PR improves the HF integration by leveraging the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class so that:
- models are pushed to separate repos
- safetensors is used for weights serialization.

Fixes #19 

Usage is as follows:

```python
from ultralytics import YOLOE

model = YOLOE.from_pretrained("nielsr/yoloe-small")

# optionally, one can push a trained model to the hub
model.push_to_hub("nielsr/my-awesome-yoloe-model")
```

Note: to be tried before we merge the PR

Kind regards,

Niels