### PR TITLE
generate label embedding from json file directly

### DIFF
--- a/tools/generate_global_neg_cat_json.py
+++ b/tools/generate_global_neg_cat_json.py
@@ -1,0 +1,84 @@
+# 官方提供的负样本挖掘脚本是针对.cache文件，而官方并没有提供这一后缀的文件，而生成.cache文件需要用到原始的数据集，对小存储空间的设备不友好。
+# 这个文件的功能是直接从json文件中提取类别名称，并统计频次，生成负样本类别列表和对应的嵌入文件。
+
+
+import numpy as np
+from pathlib import Path
+from collections import defaultdict
+import os
+import json
+from tqdm import tqdm
+from generate_label_embedding import generate_label_embedding
+import torch
+from ultralytics.utils import yaml_load
+
+def obtain_cat_freq(cache_path, cat_name_freq):
+    labels = np.load(cache_path, allow_pickle=True)
+    
+    for label in labels:
+        for text in label["texts"]:
+            for t in text:
+                t = t.strip()
+                assert(t)
+                cat_name_freq[t] += 1
+
+def obtain_cat_freq_from_json(json_path, cat_name_freq):
+    with open(json_path) as f:
+        annotations = json.load(f)
+    
+    images = {str(x["id"]): x for x in annotations["images"]}
+    img_to_anns = {str(k): [] for k in images.keys()}
+
+    for ann in annotations["annotations"]:
+        img_id_str = str(ann["image_id"])
+        if img_id_str in img_to_anns:
+            img_to_anns[img_id_str].append(ann)
+        
+    for img_id_str, anns in tqdm(img_to_anns.items(), desc=f"Processing {json_path.name}"):
+        img = images[img_id_str]
+        for ann in anns:
+            if ann["iscrowd"]:
+                continue
+            
+            cat_name = ""
+            if "tokens_positive" in ann and ann["tokens_positive"]:
+                cat_name = " ".join([img["caption"][t[0] : t[1]] for t in ann["tokens_positive"]]).lower().strip()
+            elif "category_name" in ann:
+                cat_name = ann["category_name"].lower().strip()
+            elif "category_id" in ann and "categories" in annotations:
+                cat_id = ann["category_id"]
+                for cat in annotations["categories"]:
+                    if cat["id"] == cat_id:
+                        cat_name = cat["name"].lower().strip()
+                        break
+            
+            if not cat_name:
+                continue
+            
+            cat_name_freq[cat_name] += 1
+
+if __name__ == '__main__':
+    os.environ["PYTHONHASHSEED"] = "0"
+    cat_name_freq = defaultdict(int)
+    
+    flickr_cache_path = Path('../datasets/yoloe_annotations/final_flickr_separateGT_train_segm.json')
+    obtain_cat_freq_from_json(flickr_cache_path, cat_name_freq)
+
+    mixed_grounding_cache_path = Path('../datasets/yoloe_annotations/final_mixed_train_no_coco_segm.json')
+    obtain_cat_freq_from_json(mixed_grounding_cache_path, cat_name_freq)
+
+    global_neg_cat = []
+    for k, v in cat_name_freq.items():
+        if v >= 100:
+            global_neg_cat.append(k)
+
+    print(len(global_neg_cat))
+
+    with open('tools/global_grounding_neg_cat.json', 'w') as f:
+        json.dump(global_neg_cat, f, indent=2)
+    
+    model = yaml_load('ultralytics/cfg/default.yaml')['text_model']
+    global_neg_embeddings = generate_label_embedding(model, global_neg_cat)
+    os.makedirs(f'tools/{model}', exist_ok=True)
+    torch.save(global_neg_embeddings, f'tools/{model}/global_grounding_neg_embeddings.pt')
+        

--- a/tools/generate_label_embedding.py
+++ b/tools/generate_label_embedding.py
@@ -1,9 +1,13 @@
+
+
+
 import numpy as np
 from ultralytics.utils import yaml_load
 from ultralytics.utils.torch_utils import smart_inference_mode
 import torch
 from tqdm import tqdm
 import os
+import json
 from ultralytics.nn.text_model import build_text_model
 
 @smart_inference_mode()
@@ -32,6 +36,49 @@ def collect_grounding_labels(cache_path):
     
     return cat_names
 
+def collect_grounding_labels_from_json(json_path):
+    with open(json_path) as f:
+        annotations = json.load(f)
+    
+    # 处理混合类型的ID：将所有ID转换为字符串作为键
+    images = {str(x["id"]): x for x in annotations["images"]}
+    img_to_anns = {str(k): [] for k in images.keys()}
+
+    for ann in annotations["annotations"]:
+        img_id_str = str(ann["image_id"])
+        if img_id_str in img_to_anns:
+            img_to_anns[img_id_str].append(ann)
+    
+    cat_names = set()
+    for img_id_str, anns in tqdm(img_to_anns.items(), desc=f"Processing {json_path}"):
+        img = images[img_id_str]
+        for ann in anns:
+            if ann["iscrowd"]:
+                continue
+            
+            # 处理不同数据集格式
+            cat_name = ""
+            if "tokens_positive" in ann and ann["tokens_positive"]:
+                # Grounding数据集格式 (flickr, mixed_grounding等)
+                cat_name = " ".join([img["caption"][t[0] : t[1]] for t in ann["tokens_positive"]]).lower().strip()
+            elif "category_name" in ann:
+                # 直接包含category_name字段的数据集
+                cat_name = ann["category_name"].lower().strip()
+            elif "category_id" in ann and "categories" in annotations:
+                # 通过category_id查找类别名称
+                cat_id = ann["category_id"]
+                for cat in annotations["categories"]:
+                    if cat["id"] == cat_id:
+                        cat_name = cat["name"].lower().strip()
+                        break
+            
+            if not cat_name:
+                continue
+            
+            cat_names.add(cat_name)
+    
+    return cat_names
+
 def collect_detection_labels(yaml_path):
     cat_names = set()
     
@@ -48,14 +95,16 @@ def collect_detection_labels(yaml_path):
 if __name__ == '__main__':
     os.environ["PYTHONHASHSEED"] = "0"
     
-    flickr_cache = '../datasets/flickr/annotations/final_flickr_separateGT_train_segm.cache'
-    mixed_grounding_cache = '../datasets/mixed_grounding/annotations/final_mixed_train_no_coco_segm.cache'
+    flickr_cache = '../datasets/yoloe_annotations/final_flickr_separateGT_train_segm.json'
+    mixed_grounding_cache = '../datasets/yoloe_annotations/final_mixed_train_no_coco_segm.json'
     objects365v1_yaml = 'ultralytics/cfg/datasets/Objects365v1.yaml'
+    custom_cache = '../datasets/VisDrone/annotations/train_annotations_segm.json'
     
     all_cat_names = set()
     all_cat_names |= collect_detection_labels(objects365v1_yaml)
-    all_cat_names |= collect_grounding_labels(flickr_cache)
-    all_cat_names |= collect_grounding_labels(mixed_grounding_cache)
+    all_cat_names |= collect_grounding_labels_from_json(flickr_cache)
+    all_cat_names |= collect_grounding_labels_from_json(mixed_grounding_cache)
+    all_cat_names |= collect_grounding_labels_from_json(custom_cache)
     
     all_cat_names = list(all_cat_names)
     

--- a/tools/generate_label_embedding_json.py
+++ b/tools/generate_label_embedding_json.py
@@ -1,0 +1,113 @@
+# 官方提供的负样本挖掘脚本是针对.cache文件，而官方并没有提供这一后缀的文件，而生成.cache文件需要用到原始的数据集，对小存储空间的设备不友好。
+# 这个文件的功能是直接从json文件中提取类别名称，并生成文本对应的嵌入向量。
+
+import numpy as np
+from ultralytics.utils import yaml_load
+from ultralytics.utils.torch_utils import smart_inference_mode
+import torch
+from tqdm import tqdm
+import os
+import json
+from ultralytics.nn.text_model import build_text_model
+
+@smart_inference_mode()
+def generate_label_embedding(model, texts, batch=512):
+    model = build_text_model(model, device='cuda')
+    assert(not model.training)
+    
+    text_tokens = model.tokenize(texts)
+    txt_feats = []
+    for text_token in tqdm(text_tokens.split(batch)):
+        txt_feats.append(model.encode_text(text_token))
+    txt_feats = torch.cat(txt_feats, dim=0)
+    return txt_feats.cpu()
+
+
+def collect_grounding_labels(cache_path):
+    labels = np.load(cache_path, allow_pickle=True)
+    cat_names = set()
+    
+    for label in labels:
+        for text in label["texts"]:
+            for t in text:
+                t = t.strip()
+                assert(t)
+                cat_names.add(t)
+    
+    return cat_names
+
+def collect_grounding_labels_from_json(json_path):
+    with open(json_path) as f:
+        annotations = json.load(f)
+    
+    images = {str(x["id"]): x for x in annotations["images"]}
+    img_to_anns = {str(k): [] for k in images.keys()}
+
+    for ann in annotations["annotations"]:
+        img_id_str = str(ann["image_id"])
+        if img_id_str in img_to_anns:
+            img_to_anns[img_id_str].append(ann)
+    
+    cat_names = set()
+    for img_id_str, anns in tqdm(img_to_anns.items(), desc=f"Processing {json_path}"):
+        img = images[img_id_str]
+        for ann in anns:
+            if ann["iscrowd"]:
+                continue
+            
+            cat_name = ""
+            if "tokens_positive" in ann and ann["tokens_positive"]:
+                cat_name = " ".join([img["caption"][t[0] : t[1]] for t in ann["tokens_positive"]]).lower().strip()
+            elif "category_name" in ann:
+                cat_name = ann["category_name"].lower().strip()
+            elif "category_id" in ann and "categories" in annotations:
+                cat_id = ann["category_id"]
+                for cat in annotations["categories"]:
+                    if cat["id"] == cat_id:
+                        cat_name = cat["name"].lower().strip()
+                        break
+            
+            if not cat_name:
+                continue
+            
+            cat_names.add(cat_name)
+    
+    return cat_names
+
+def collect_detection_labels(yaml_path):
+    cat_names = set()
+    
+    data = yaml_load(yaml_path, append_filename=True)
+    names = [name.split("/") for name in data["names"].values()]
+    for name in names:
+        for n in name:
+            n = n.strip()
+            assert(n)
+            cat_names.add(n)
+    
+    return cat_names
+
+if __name__ == '__main__':
+    os.environ["PYTHONHASHSEED"] = "0"
+    
+    flickr_cache = '../datasets/yoloe_annotations/final_flickr_separateGT_train_segm.json'
+    mixed_grounding_cache = '../datasets/yoloe_annotations/final_mixed_train_no_coco_segm.json'
+    objects365v1_yaml = 'ultralytics/cfg/datasets/Objects365v1.yaml'
+    
+    all_cat_names = set()
+    all_cat_names |= collect_detection_labels(objects365v1_yaml)
+    all_cat_names |= collect_grounding_labels_from_json(flickr_cache)
+    all_cat_names |= collect_grounding_labels_from_json(mixed_grounding_cache)
+    # all_cat_names |= collect_grounding_labels_from_json(custom_cache)
+    
+    all_cat_names = list(all_cat_names)
+    
+    model = yaml_load('ultralytics/cfg/default.yaml')['text_model']
+    all_cat_feats = generate_label_embedding(model, all_cat_names)
+    
+    cat_name_feat_map = {}
+    for name, feat in zip(all_cat_names, all_cat_feats):
+        cat_name_feat_map[name] = feat
+    
+    os.makedirs(f'tools/{model}', exist_ok=True)
+    torch.save(cat_name_feat_map, f'tools/{model}/train_label_embeddings.pt')


### PR DESCRIPTION
官方提供的负样本挖掘脚本是针对.cache文件，而官方并没有提供这一后缀的文件，而生成.cache文件需要用到原始的数据集，对小存储空间的设备不友好。
这两个提交文件的功能是直接从json文件中提取类别名称，并生成文本对应的嵌入向量。